### PR TITLE
Added task for compiling the project in Tweego watch mode.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
             ]
         },
         {
-            "label": "Tweego Compile Continious",
+            "label": "Tweego Compile Continuous",
             "type": "shell",
             "command": "tweego.exe -w -o './out/index.html' src",
             "dependsOn": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,6 +17,14 @@
             ]
         },
         {
+            "label": "Tweego Compile Continious",
+            "type": "shell",
+            "command": "tweego.exe -w -o './out/index.html' src",
+            "dependsOn": [
+                "Ensure Output Directory"
+            ],
+        },
+        {
             "label": "Copy Static Resources",
             "type": "shell",
             "command": "Copy-Item -Path ./web/* -Destination ./out -Recurse -Force",


### PR DESCRIPTION
Since Erios mentioned he mostly uses the Tweego compiler in watch mode.

Added task "Tweego Compile Continuous" that launches the compiler in watch mode scanning for changes in the src/* directory and updating the compiled file in ./out/index.html

The task can be run as a regular VS Code task and it will stay alive until cancelled in the VS Code terminal.

Static resource files still need to be updated manually in the output directory via running the "Copy Static Resources" task, running a general build task or copying them manually.